### PR TITLE
Minor startup errors fixes

### DIFF
--- a/edgedns.toml
+++ b/edgedns.toml
@@ -19,7 +19,7 @@ max_failures = 3
 max_items = 250000
 
 # Minimum TTL - Records with a TTL shorter than that one will not trigger a
-# cache refrseh. Increasing that value increases the cache hit ratio,
+# cache refresh. Increasing that value increases the cache hit ratio,
 # improves reliability and reduces the load on upstream servers, but zones
 # changes will obviously require more time to be visible by clients.
 min_ttl = 60

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ fn main() {
     let config_file = match matches.value_of("config_file") {
         None => {
             error!("A path to the configuration file is required");
-            return;
+            std::process::exit(1);
         }
         Some(config_file) => config_file,
     };
@@ -226,12 +226,15 @@ fn main() {
             error!("The configuration couldn't be loaded -- [{}]: [{}]",
                    config_file,
                    err);
-            return;
+            std::process::exit(1);
         }
         Ok(config) => config,
     };
     match EdgeDNS::new(config) {
-        Err(errstr) => error!("Failed to start EdgeDNS: {}", errstr),
+        Err(errstr) => {
+            error!("Failed to start EdgeDNS: {}", errstr);
+            std::process::exit(1);
+        },
         Ok(_) => return,
     }
 }

--- a/src/net_helpers.rs
+++ b/src/net_helpers.rs
@@ -39,8 +39,8 @@ pub fn socket_tcp_bound(addr: &str) -> io::Result<net::TcpListener> {
     let _ = setsockopt(socket_fd, sockopt::ReusePort, &true);
     let _ = setsockopt(socket_fd, sockopt::TcpNoDelay, &true);
     let _ = socket_priority::set_priority(socket_fd, socket_priority::Priority::Interactive);
-    bind(socket_fd, &nix_addr).expect("Unable to bind a TCP socket");
-    listen(socket_fd, TCP_BACKLOG).expect("Unable to listen to the TCP socket");
+    bind(socket_fd, &nix_addr)?;
+    listen(socket_fd, TCP_BACKLOG)?;
     let socket = unsafe { net::TcpListener::from_raw_fd(socket_fd) };
     Ok(socket)
 }
@@ -87,7 +87,7 @@ pub fn socket_udp_bound(addr: &str) -> io::Result<UdpSocket> {
     let _ = set_bpf_udp_dns(socket_fd);
     let _ = socket_priority::set_priority(socket_fd, socket_priority::Priority::Interactive);
     socket_udp_set_buffer_size(socket_fd);
-    bind(socket_fd, &nix_addr).expect("Unable to bind a UDP socket");
+    bind(socket_fd, &nix_addr)?;
     let socket = unsafe { UdpSocket::from_raw_fd(socket_fd) };
     Ok(socket)
 }


### PR DESCRIPTION
We currently panic in `socket_{udp,tcp}_bound` if an error happens in
bind() or listen(), this commit forwards the error to the caller instead.

```
$ ./target/debug/edgedns -c ./edgedns.toml
thread 'main' panicked at 'Unable to bind a UDP socket: Sys(EACCES)', /checkout/src/libcore/result.rs:859
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```
vs
```
ERROR:edgedns: Failed to start EdgeDNS: Unable to create a UDP client socket (0.0.0.0:53): Permission denied (os error 13)H
```

minor: fix a typo in edgedns.toml and we use `std::process:exit` to explicitly set an error when the startup fails