### PR TITLE
Testing based on CoreDNS and dig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
             # Transparent emulation
             - qemu-user-static
             - binfmt-support
-            - dnsutils
     - os: linux
       rust: nightly
       env: TARGET=armv7-unknown-linux-gnueabihf
@@ -39,7 +38,6 @@ matrix:
             # Transparent emulation
             - qemu-user-static
             - binfmt-support
-            - dnsutils
     - os: linux
       rust: nightly
       env: TARGET=i686-unknown-linux-gnu
@@ -48,7 +46,6 @@ matrix:
           packages: &i686_unknown_linux_gnu
             # Cross compiler and cross compiled C libraries
             - gcc-multilib
-            - dnsutils
     - os: osx
       rust: nightly
       env: TARGET=x86_64-apple-darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,11 @@ matrix:
     - os: linux
       rust: nightly
       env: TARGET=x86_64-unknown-linux-gnu
+      addons:
+        apt:
+          packages:
+            # For tests
+            - dnsutils
 
   allow_failures:
     # TODO You might need to allow failures for some target on some channel for some reason. Below

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
             # Transparent emulation
             - qemu-user-static
             - binfmt-support
+            - dnsutils
     - os: linux
       rust: nightly
       env: TARGET=armv7-unknown-linux-gnueabihf
@@ -38,6 +39,7 @@ matrix:
             # Transparent emulation
             - qemu-user-static
             - binfmt-support
+            - dnsutils
     - os: linux
       rust: nightly
       env: TARGET=i686-unknown-linux-gnu
@@ -46,6 +48,7 @@ matrix:
           packages: &i686_unknown_linux_gnu
             # Cross compiler and cross compiled C libraries
             - gcc-multilib
+            - dnsutils
     - os: osx
       rust: nightly
       env: TARGET=x86_64-apple-darwin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,8 @@ dependencies = [
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libedgedns 0.3.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -657,6 +658,18 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "tempfile"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "term_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +925,7 @@ dependencies = [
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
+"checksum tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3213fd2b7ed87e39306737ccfac04b1233b57a33ca64cfbf52f2ffaa2b765e2f"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8df7875b676fddfadffd96deea3b1124e5ede707d4884248931077518cf1f773"
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ clippy = ["libedgedns/clippy"]
 
 default = ["nightly", "webservice"]
 
+[dev-dependencies]
+nix = "*"
+regex = "*"
+
 [dependencies.libedgedns]
 path = "src/libedgedns"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ default = ["nightly", "webservice"]
 [dev-dependencies]
 nix = "*"
 regex = "*"
+tempfile = "*"
 
 [dependencies.libedgedns]
 path = "src/libedgedns"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -52,7 +52,6 @@ main() {
     configure_cargo
 
     # TODO if you need to install extra stuff add it here
-    sudo apt-get install -y dnsutils
 }
 
 main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -52,7 +52,7 @@ main() {
     configure_cargo
 
     # TODO if you need to install extra stuff add it here
-    apt-get install -y dnsutils
+    sudo apt-get install -y dnsutils
 }
 
 main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -52,6 +52,7 @@ main() {
     configure_cargo
 
     # TODO if you need to install extra stuff add it here
+    apt-get install -y dnsutils
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -27,8 +27,12 @@ run_test_suite() {
     fi
 
     cargo build --target $TARGET --verbose
-    install_coredns
-    RUST_BACKTRACE=1 cargo test --target $TARGET
+    case $TARGET in
+	    x86_64-unknown-linux-gnu)
+            install_coredns
+	    RUST_BACKTRACE=1 cargo test --target $TARGET
+            ;;
+    esac
 
     # sanity check the file type
     file target/$TARGET/debug/edgedns

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -27,6 +27,7 @@ run_test_suite() {
     fi
 
     cargo build --target $TARGET --verbose
+    install_coredns
     cargo test --target $TARGET
 
     # sanity check the file type

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -28,7 +28,7 @@ run_test_suite() {
 
     cargo build --target $TARGET --verbose
     install_coredns
-    cargo test --target $TARGET
+    RUST_BACKTRACE=1 cargo test --target $TARGET
 
     # sanity check the file type
     file target/$TARGET/debug/edgedns

--- a/ci/utils.sh
+++ b/ci/utils.sh
@@ -69,3 +69,14 @@ architecture() {
             ;;
     esac
 }
+
+install_coredns() {
+    eval "$(GIMME_GO_VERSION=1.8 gimme)"
+    local tmpd=$(mktempd)
+    go version
+    cd $tmpd
+    export GOPATH=$(pwd)
+    go get github.com/coredns/coredns
+    export PATH=${tmpd}/bin:$PATH
+    cd -
+}

--- a/src/libedgedns/src/lib.rs
+++ b/src/libedgedns/src/lib.rs
@@ -163,8 +163,10 @@ impl EdgeDNS {
         let cache = Cache::new(config.clone());
         let udp_socket = socket_udp_bound(&config.listen_addr)
             .expect("Unable to create a UDP client socket");
+        info!("Created a UDP socket: {:?}", udp_socket.local_addr().unwrap().port());
         let tcp_listener = socket_tcp_bound(&config.listen_addr)
             .expect("Unable to create a TCP client socket");
+        info!("Created a UDP socket: {:?}", tcp_listener.local_addr().unwrap().port());
         let (log_dnstap, dnstap_sender) = if config.dnstap_enabled {
             let log_dnstap = LogDNSTap::new(&config);
             let dnstap_sender = log_dnstap.sender();

--- a/src/libedgedns/src/lib.rs
+++ b/src/libedgedns/src/lib.rs
@@ -166,7 +166,7 @@ impl EdgeDNS {
         info!("Created a UDP socket: {:?}", udp_socket.local_addr().unwrap().port());
         let tcp_listener = socket_tcp_bound(&config.listen_addr)
             .expect("Unable to create a TCP client socket");
-        info!("Created a UDP socket: {:?}", tcp_listener.local_addr().unwrap().port());
+        info!("Created a TCP socket: {:?}", tcp_listener.local_addr().unwrap().port());
         let (log_dnstap, dnstap_sender) = if config.dnstap_enabled {
             let log_dnstap = LogDNSTap::new(&config);
             let dnstap_sender = log_dnstap.sender();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,68 @@
+extern crate libedgedns;
+extern crate nix;
+extern crate regex;
+
+
+#[cfg(test)]
+mod test {
+    extern crate env_logger;
+    use libedgedns::{Config, EdgeDNS};
+    use std::thread;
+    use std::env;
+    use std::process::Command;
+    use nix::sys::signal::*;
+    use nix::unistd::*;
+    use nix::sys::socket::{socketpair, AddressFamily, SockType, SockFlag};
+    use regex::Regex;
+
+
+
+    #[test]
+    fn empty_config_test() {
+        let (fdc, fdp) = socketpair(AddressFamily::Unix, SockType::Stream, 0, SockFlag::empty()).expect("socketpair");
+        match fork().expect("fork failed") {
+            ForkResult::Parent{ child } => {
+                let mut s = String::new();
+                loop {
+                    let mut buf = [0;1];
+                    let res = read(fdp, &mut buf);
+                    if res.is_err() {
+                        break;
+                    }
+                    let res = res.unwrap();
+                    if res > 0 {
+                        s.push(buf[0] as char);
+
+                    }
+                    if s.contains("UDP listener is ready") && s.contains("TCP listener is ready") {
+                        break;
+                    }
+                }
+                let re = Regex::new(r"Created a UDP socket: (\d+)").unwrap();
+                for cap in re.captures_iter(&s) {
+                    println!("UDP ports: {}", &cap[1]);
+                }
+
+                kill(child, SIGKILL).expect("kill failed");
+            }
+            ForkResult::Child => {
+                env::set_var("RUST_LOG", "info");
+                dup2(fdc, 2);
+                env_logger::init().expect("Failed to init logger");
+                let config = Config::from_string(r#"
+[upstream]
+servers = ["8.8.8.8:53"]
+[network]
+listen = "127.0.0.1:0"
+udp_ports = 1
+[global]
+threads_udp = 1
+threads_tcp = 1
+"#);
+                assert!(config.is_ok());
+                EdgeDNS::new(config.unwrap());
+            }
+        }
+
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,24 +7,41 @@ extern crate regex;
 mod test {
     extern crate env_logger;
     use libedgedns::{Config, EdgeDNS};
-    use std::thread;
     use std::env;
-    use std::process::Command;
-    use nix::sys::signal::*;
+    use std::os::unix::io::RawFd;
+    use nix::sys::signal::{kill, SIGKILL};
+    use nix::sys::ioctl::libc::pid_t;
     use nix::unistd::*;
     use nix::sys::socket::{socketpair, AddressFamily, SockType, SockFlag};
     use regex::Regex;
+    use std::process::{Output, Command, ExitStatus};
+    use std::string::String;
 
-
-
-    #[test]
-    fn empty_config_test() {
-        let (fdc, fdp) = socketpair(AddressFamily::Unix, SockType::Stream, 0, SockFlag::empty()).expect("socketpair");
+    struct EdgeDNSInstance {
+        stdout: RawFd,
+        pid: pid_t,
+        udp_ports: Vec<u16>,
+    }
+    impl EdgeDNSInstance {
+        pub fn done(&self) {
+            kill(self.pid, SIGKILL).expect("kill failed")
+        }
+    }
+    fn spawn_edgedns(cfg_str: &str) -> EdgeDNSInstance {
+        let mut ret = EdgeDNSInstance {
+            pid: 0,
+            stdout: 0,
+            udp_ports: Vec::new(),
+        };
+        let (fdc, fdp) = socketpair(AddressFamily::Unix, SockType::Stream, 0, SockFlag::empty())
+            .expect("socketpair");
         match fork().expect("fork failed") {
-            ForkResult::Parent{ child } => {
+            ForkResult::Parent { child } => {
+                ret.pid = child;
+                ret.stdout = fdp;
                 let mut s = String::new();
                 loop {
-                    let mut buf = [0;1];
+                    let mut buf = [0; 1];
                     let res = read(fdp, &mut buf);
                     if res.is_err() {
                         break;
@@ -40,16 +57,25 @@ mod test {
                 }
                 let re = Regex::new(r"Created a UDP socket: (\d+)").unwrap();
                 for cap in re.captures_iter(&s) {
-                    println!("UDP ports: {}", &cap[1]);
+                    ret.udp_ports.push(cap[1].parse::<u16>().unwrap());
                 }
-
-                kill(child, SIGKILL).expect("kill failed");
             }
             ForkResult::Child => {
                 env::set_var("RUST_LOG", "info");
-                dup2(fdc, 2);
+                dup2(fdc, 2).expect("dup2 failed"); /* have env_logger log to the socketpair */
                 env_logger::init().expect("Failed to init logger");
-                let config = Config::from_string(r#"
+                let config = Config::from_string(cfg_str);
+                assert!(config.is_ok());
+                EdgeDNS::new(config.unwrap());
+            }
+        }
+        ret
+    }
+
+
+    #[test]
+    fn empty_config() {
+        let cfg = r#"
 [upstream]
 servers = ["8.8.8.8:53"]
 [network]
@@ -58,11 +84,63 @@ udp_ports = 1
 [global]
 threads_udp = 1
 threads_tcp = 1
-"#);
-                assert!(config.is_ok());
-                EdgeDNS::new(config.unwrap());
-            }
-        }
+"#;
+        let server = spawn_edgedns(&cfg);
+        server.done();
+    }
 
+    enum Qprotocol {
+        UDP,
+        TCP,
+    }
+    struct CmdOutput {
+        stdout: String,
+        stderr: String,
+        status: ExitStatus,
+    }
+    fn dig(query: &str, proto: Qprotocol, server: &str, port: u16) -> CmdOutput {
+        let output = Command::new("dig")
+            .arg(query)
+            .arg(format!("@{}", server))
+            .arg("-p")
+            .arg(format!("{}", port))
+            .output()
+            .unwrap();
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        match String::from_utf8(output.stdout) {
+            Err(_) => (),
+            Ok(s) => stdout = s,
+        }
+        match String::from_utf8(output.stderr) {
+            Err(_) => (),
+            Ok(s) => stderr = s,
+        }
+        CmdOutput {
+            stdout: stdout,
+            stderr: stderr,
+            status: output.status,
+        }
+    }
+
+    #[test]
+    fn simple_dig_query() {
+        let cfg = r#"
+[upstream]
+servers = ["8.8.8.8:53"]
+[network]
+listen = "127.0.0.1:0"
+udp_ports = 1
+[global]
+threads_udp = 1
+threads_tcp = 1
+"#;
+        let server = spawn_edgedns(&cfg);
+        let re = Regex::new(r"\n;; ANSWER SECTION:\n127.0.0.1.xip.io.\s+\d+\s+IN\s+A\s+127.0.0.1")
+            .unwrap();
+        for port in &server.udp_ports {
+            assert!(re.is_match(&dig("127.0.0.1.xip.io", Qprotocol::UDP, "127.0.0.1", *port).stdout));
+        }
+        server.done();
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -71,24 +71,6 @@ mod test {
         }
         ret
     }
-
-
-    #[test]
-    fn empty_config() {
-        let cfg = r#"
-[upstream]
-servers = ["8.8.8.8:53"]
-[network]
-listen = "127.0.0.1:0"
-udp_ports = 1
-[global]
-threads_udp = 1
-threads_tcp = 1
-"#;
-        let server = spawn_edgedns(&cfg);
-        server.done();
-    }
-
     enum Qprotocol {
         UDP,
         TCP,
@@ -121,6 +103,24 @@ threads_tcp = 1
             stderr: stderr,
             status: output.status,
         }
+    }
+
+    /* tests */
+
+    #[test]
+    fn empty_config() {
+        let cfg = r#"
+[upstream]
+servers = ["8.8.8.8:53"]
+[network]
+listen = "127.0.0.1:0"
+udp_ports = 1
+[global]
+threads_udp = 1
+threads_tcp = 1
+"#;
+        let server = spawn_edgedns(&cfg);
+        server.done();
     }
 
     #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,45 +1,77 @@
 extern crate libedgedns;
 extern crate nix;
 extern crate regex;
-
+extern crate tempfile;
 
 #[cfg(test)]
 mod test {
     extern crate env_logger;
     use libedgedns::{Config, EdgeDNS};
-    use std::env;
-    use std::os::unix::io::RawFd;
+
     use nix::sys::signal::{kill, SIGKILL};
     use nix::sys::ioctl::libc::pid_t;
-    use nix::unistd::*;
+    use nix::unistd::{fork, read, ForkResult, dup2};
+    use nix::sys::ioctl::libc::alarm;
     use nix::sys::socket::{socketpair, AddressFamily, SockType, SockFlag};
+
     use regex::Regex;
-    use std::process::{Output, Command, ExitStatus};
+
+    use std::env;
+    use std::io::Write;
+    use std::process::{exit, Output, Command, ExitStatus};
+    use std::os::unix::io::RawFd;
+    use std::os::unix::process::CommandExt;
     use std::string::String;
+    use std::time::Duration;
+
+    use tempfile::NamedTempFile;
 
     struct EdgeDNSInstance {
-        stdout: RawFd,
-        pid: pid_t,
+        server: Server,
         udp_ports: Vec<u16>,
+        tcp_ports: Vec<u16>,
     }
-    impl EdgeDNSInstance {
-        pub fn done(&self) {
-            kill(self.pid, SIGKILL).expect("kill failed")
+
+    struct Server {
+        pid: pid_t,
+        startup_text: String,
+        output: RawFd,
+    }
+    impl Server {
+            pub fn new() -> Server {
+                Server{pid: 0, startup_text: String::from(""), output: 0}
+            }
+    }
+
+    impl Drop for Server {
+        fn drop(&mut self) {
+            if self.pid != 0 {
+                kill(self.pid, SIGKILL).expect("kill failed")
+            }
         }
     }
-    fn spawn_edgedns(cfg_str: &str) -> EdgeDNSInstance {
-        let mut ret = EdgeDNSInstance {
+
+    fn spawn_server<F1, F2>(child_fn: F1, mut is_ready: F2, timeout: Duration) -> Server
+        where F1: Fn() -> (),
+              F2: FnMut(&str, pid_t) -> bool
+    {
+
+        let mut server = Server {
             pid: 0,
-            stdout: 0,
-            udp_ports: Vec::new(),
+            output: 0,
+            startup_text: String::new(),
         };
         let (fdc, fdp) = socketpair(AddressFamily::Unix, SockType::Stream, 0, SockFlag::empty())
             .expect("socketpair");
         match fork().expect("fork failed") {
             ForkResult::Parent { child } => {
-                ret.pid = child;
-                ret.stdout = fdp;
-                let mut s = String::new();
+                server.pid = child;
+                server.output = fdp;
+
+                /* FIXME: a non-unsafe way to do this */
+                unsafe {
+                    alarm(timeout.as_secs() as u32);
+                }
                 loop {
                     let mut buf = [0; 1];
                     let res = read(fdp, &mut buf);
@@ -48,29 +80,111 @@ mod test {
                     }
                     let res = res.unwrap();
                     if res > 0 {
-                        s.push(buf[0] as char);
-
+                        server.startup_text.push(buf[0] as char);
                     }
-                    if s.contains("UDP listener is ready") && s.contains("TCP listener is ready") {
+                    if is_ready(&server.startup_text, child) {
                         break;
                     }
                 }
-                let re = Regex::new(r"Created a UDP socket: (\d+)").unwrap();
-                for cap in re.captures_iter(&s) {
-                    ret.udp_ports.push(cap[1].parse::<u16>().unwrap());
+                unsafe {
+                    alarm(0);
                 }
             }
             ForkResult::Child => {
-                env::set_var("RUST_LOG", "info");
-                dup2(fdc, 2).expect("dup2 failed"); /* have env_logger log to the socketpair */
-                env_logger::init().expect("Failed to init logger");
-                let config = Config::from_string(cfg_str);
-                assert!(config.is_ok());
-                EdgeDNS::new(config.unwrap());
+                dup2(fdc, 1).expect("dup2 failed");
+                dup2(fdc, 2).expect("dup2 failed");
+                child_fn();
+                println!("The child exited");
+                exit(0);
             }
         }
+        server
+    }
+
+    fn spawn_edgedns(cfg_str: &str) -> EdgeDNSInstance {
+        let mut ret = EdgeDNSInstance {
+            udp_ports: Vec::new(),
+            tcp_ports: Vec::new(),
+            server: spawn_server(|| {
+                                     env::set_var("RUST_LOG", "info");
+                                     env_logger::init().expect("Failed to init logger");
+                                     let config = Config::from_string(cfg_str);
+                                     assert!(config.is_ok());
+                                     EdgeDNS::new(config.unwrap());
+                                 },
+                                 |out, _| {
+                                     out.contains("UDP listener is ready") &&
+                                     out.contains("TCP listener is ready")
+                                 },
+                                 Duration::new(5, 0)),
+        };
+
+        for proto in ["TCP", "UDP"].iter() {
+            let re = Regex::new(&format!(r"Created a {} socket: (\d+)", proto)).unwrap();
+            for cap in re.captures_iter(&ret.server.startup_text) {
+                let port = cap[1].parse::<u16>().unwrap();
+                if *proto == "UDP" {
+                    ret.udp_ports.push(port);
+                } else {
+                    ret.tcp_ports.push(port);
+                }
+            }
+        }
+
         ret
     }
+
+    struct CoreDNS {
+        server: Server,
+        udp_port: u16,
+    }
+
+    fn spawn_coredns(domain: &str, zone_str: &str) -> CoreDNS {
+        let mut conf_file = NamedTempFile::new().unwrap();
+        let mut zone_file = NamedTempFile::new().unwrap();
+        zone_file.write_all(zone_str.as_bytes());
+        let zfile_path = zone_file.path().to_str().unwrap();
+        let conf_str = format!(r#"
+{}:0 {{
+    file {}
+    errors stdout
+    log stdout
+}}
+"#, domain, zfile_path);
+        conf_file.write_all(conf_str.as_bytes());
+        let cfile_path = conf_file.path().to_str().unwrap();
+        let mut ret = CoreDNS {
+            udp_port : 0,
+            server: Server::new(),
+        };
+        ret.server = spawn_server(|| {
+                let cmd = Command::new("coredns")
+                    .args(&["-log", "-dns.port", "0", "-conf", cfile_path])
+                    .exec();
+                ::std::process::exit(1);
+            },
+            |out, pid| {
+                if !out.contains("CoreDNS-008") {
+                    return false;
+                }
+                let lsof = Command::new("lsof")
+                    .arg("-p")
+                    .arg(&format!("{}", pid))
+                    .output();
+                let lsof = String::from_utf8(lsof.unwrap().stdout).unwrap();
+
+                let re = Regex::new(r"0t0\s+UDP \*:(\d+)").unwrap();
+                let mut udp_port: u16 = 0;
+                for cap in re.captures_iter(&lsof) {
+                    udp_port = cap[1].parse::<u16>().unwrap();
+                }
+                ret.udp_port = udp_port;
+                true
+            },
+            Duration::new(5, 0));
+        ret
+    }
+
     enum Qprotocol {
         UDP,
         TCP,
@@ -81,13 +195,14 @@ mod test {
         status: ExitStatus,
     }
     fn dig(query: &str, proto: Qprotocol, server: &str, port: u16) -> CmdOutput {
-        let output = Command::new("dig")
-            .arg(query)
-            .arg(format!("@{}", server))
-            .arg("-p")
-            .arg(format!("{}", port))
-            .output()
-            .unwrap();
+        let server = format!("@{}", server);
+        let port = format!("{}", port);
+        let mut args = vec![query, &server, "-p", &port];
+        match proto {
+            Qprotocol::TCP => args.push("+tcp"),
+            _ => (),
+        }
+        let output = Command::new("dig").args(args).output().unwrap();
         let mut stdout = String::new();
         let mut stderr = String::new();
         match String::from_utf8(output.stdout) {
@@ -106,6 +221,49 @@ mod test {
     }
 
     /* tests */
+    #[test]
+    fn coredns_test() {
+        let coredns = spawn_coredns("example.com", r#"
+$ORIGIN example.com.     ; designates the start of this zone file in the namespace
+$TTL 1h                  ; default expiration time of all resource records without their own TTL value
+example.com.  IN  SOA   ns.example.com. username.example.com. ( 2007120710 1d 2h 4w 1h )
+example.com.  IN  NS    ns                    ; ns.example.com is a nameserver for example.com
+example.com.  IN  NS    ns.somewhere.example. ; ns.somewhere.example is a backup nameserver for example.com
+example.com.  IN  MX    10 mail.example.com.  ; mail.example.com is the mailserver for example.com
+@             IN  MX    20 mail2.example.com. ; equivalent to above line, "@" represents zone origin
+@             IN  MX    50 mail3              ; equivalent to above line, but using a relative host name
+example.com.  IN  A     192.0.2.1             ; IPv4 address for example.com
+IN  AAAA  2001:db8:10::1        ; IPv6 address for example.com
+ns            IN  A     192.0.2.2             ; IPv4 address for ns.example.com
+IN  AAAA  2001:db8:10::2        ; IPv6 address for ns.example.com
+www           IN  CNAME example.com.          ; www.example.com is an alias for example.com
+wwwtest       IN  CNAME www                   ; wwwtest.example.com is another alias for www.example.com
+mail          IN  A     192.0.2.3             ; IPv4 address for mail.example.com
+mail2         IN  A     192.0.2.4             ; IPv4 address for mail2.example.com
+mail3         IN  A     192.0.2.5             ; IPv4 address for mail3.example.com
+"#);
+        let cfg = format!(r#"
+[upstream]
+servers = ["127.0.0.1:{}"]
+[network]
+listen = "127.0.0.1:0"
+udp_ports = 1
+[global]
+threads_udp = 1
+threads_tcp = 1
+"#, coredns.udp_port);
+        let server = spawn_edgedns(&cfg);
+        let re = Regex::new(r"\n;; ANSWER SECTION:\nmail.example.com.\s+\d+\s+IN\s+A\s+192.0.2.3").unwrap();
+        for port in &server.udp_ports {
+            let output = dig("mail.example.com", Qprotocol::UDP, "127.0.0.1", *port).stdout;
+            assert!(re.is_match(&output));
+        }
+        for port in &server.tcp_ports {
+            let output = dig("127.0.0.1.xip.io", Qprotocol::TCP, "127.0.0.1", *port).stdout;
+            println!("{}", output);
+            assert!(re.is_match(&output));
+        }
+    }
 
     #[test]
     fn empty_config() {
@@ -120,7 +278,6 @@ threads_udp = 1
 threads_tcp = 1
 "#;
         let server = spawn_edgedns(&cfg);
-        server.done();
     }
 
     #[test]
@@ -139,8 +296,12 @@ threads_tcp = 1
         let re = Regex::new(r"\n;; ANSWER SECTION:\n127.0.0.1.xip.io.\s+\d+\s+IN\s+A\s+127.0.0.1")
             .unwrap();
         for port in &server.udp_ports {
-            assert!(re.is_match(&dig("127.0.0.1.xip.io", Qprotocol::UDP, "127.0.0.1", *port).stdout));
+            let output = dig("127.0.0.1.xip.io", Qprotocol::UDP, "127.0.0.1", *port).stdout;
+            assert!(re.is_match(&output));
         }
-        server.done();
+        for port in &server.tcp_ports {
+            let output = dig("127.0.0.1.xip.io", Qprotocol::TCP, "127.0.0.1", *port).stdout;
+            assert!(re.is_match(&output));
+        }
     }
 }


### PR DESCRIPTION
This PR adds a test module that includes a couple of helper functions that allow to write tests using `dig` as a client and `coredns` as a backend. See `coredns_test()` and `empty_config()` for examples.

In order for the PR to work, I've had to skip `cargo test` on everything but x86_64. The ARM platforms fail because of QEMU emulation issues, and I haven't dug how to install `dig` on MacOSX. Please let me know if you think that's worth pursuing.